### PR TITLE
Devise undefined method reference patch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.0.2"
+ruby "2.7.2"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.0.alpha2"
@@ -65,4 +65,4 @@ group :test do
   gem "webdrivers"
 end
 
-gem "devise", "~> 4.8"
+gem 'devise', github: 'ghiculescu/devise', branch: 'patch-2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/ghiculescu/devise.git
+  revision: e37ea6a0143b9b8a3477b1ed397d8a22ad317a61
+  branch: patch-2
+  specs:
+    devise (4.7.3)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0)
+      responders
+      warden (~> 1.2.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -80,12 +92,6 @@ GEM
     debug (1.1.0)
       irb
       reline (>= 0.2.7)
-    devise (4.8.0)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
-      responders
-      warden (~> 1.2.3)
     erubi (1.10.0)
     globalid (0.5.2)
       activesupport (>= 5.0)
@@ -106,9 +112,13 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.1)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.8)
+    nokogiri (1.12.4)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     nokogiri (1.12.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.4-x86_64-darwin)
@@ -194,13 +204,14 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  ruby
   x86_64-darwin-20
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   capybara (>= 3.26)
   debug (>= 1.0.0)
-  devise (~> 4.8)
+  devise!
   importmap-rails (>= 0.3.4)
   jbuilder (~> 2.7)
   puma (~> 5.0)
@@ -214,7 +225,7 @@ DEPENDENCIES
   webdrivers
 
 RUBY VERSION
-   ruby 3.0.2p107
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.2.27


### PR DESCRIPTION
with the instructions [here](http://www.yetanother.site/rails/2021/07/06/Tracking-Rails-Main-Part-2.html)

I was able to resolve my `NoMethodError: undefined method `reference' for ActiveSupport::Dependencies:Module` issue