### PR TITLE
Move fields to Homes table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :test do
   gem "capybara", ">= 3.26"
   gem "selenium-webdriver"
   gem "webdrivers"
+  gem 'rexml', '~> 3.2.5'
 end
 
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,7 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rexml (3.2.5)
     rubyzip (2.3.2)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
@@ -215,6 +216,7 @@ DEPENDENCIES
   pg (~> 1.2)
   puma (~> 5.0)
   rails (~> 7.0.0.alpha2)
+  rexml (~> 3.2.5)
   selenium-webdriver
   stimulus-rails (>= 0.4.0)
   turbo-rails (>= 0.7.11)

--- a/app/controllers/fosters_controller.rb
+++ b/app/controllers/fosters_controller.rb
@@ -48,6 +48,8 @@ class FostersController < PasswordProtectedController
 
   # DELETE /fosters/1 or /fosters/1.json
   def destroy
+    @home = Home.find_by(foster_id: params[:id])
+    @home.destroy
     @foster.destroy
     respond_to do |format|
       format.html { redirect_to fosters_url, notice: "Foster was successfully destroyed." }

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -64,6 +64,6 @@ class HomesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def home_params
-      params.fetch(:home, {})
+      params.fetch(:home, {}).permit(:foster_id)
     end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -19,21 +19,6 @@ class HomesController < ApplicationController
   def edit
   end
 
-  # POST /homes or /homes.json
-  def create
-    @home = Home.new(home_params)
-
-    respond_to do |format|
-      if @home.save
-        format.html { redirect_to @home, notice: "Home was successfully created." }
-        format.json { render :show, status: :created, location: @home }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @home.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
   # PATCH/PUT /homes/1 or /homes/1.json
   def update
     respond_to do |format|
@@ -64,6 +49,6 @@ class HomesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def home_params
-      params.fetch(:home, {}).permit(:foster_id)
+      params.fetch(:home, {})
     end
 end

--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -3,6 +3,7 @@ class SignupsController < PasswordlessController
 
   def create
     @foster = Foster.new(foster_params)
+    @home = foster_params['home']
 
     if @foster.save
       session = build_passwordless_session(@foster)
@@ -30,7 +31,15 @@ class SignupsController < PasswordlessController
       :street,
       :apt,
       :is_home_during_day,
-      :transportation
+      :transportation,
+      home_attributes: [
+        :id,
+        :has_children,
+        :has_fenced_yard,
+        :has_other_adults,
+        :has_other_dog,
+        :has_other_cat
+      ]
     )
   end
 

--- a/app/models/foster.rb
+++ b/app/models/foster.rb
@@ -7,6 +7,9 @@ class Foster < ApplicationRecord
   
   enum transportation: [ :access_to_car, :car, :no_car ]
 
+  has_one :home
+  accepts_nested_attributes_for :home
+
   validates :full_name, presence: true
   validates :street, presence: true
   validates :is_home_during_day, presence: true

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -1,2 +1,3 @@
 class Home < ApplicationRecord
+  belongs_to :foster
 end

--- a/app/views/signups/_home_section.html.erb
+++ b/app/views/signups/_home_section.html.erb
@@ -1,31 +1,31 @@
 <h2 class="home_info">HOME INFORMATION</h2>
 
 <div class="foster_is_home_container">
-  <%= f.label "Are you or another adult home during the day?" %>
-  <br>
-  <%= f.radio_button :is_home_during_day, true, :checked => true %> Yes
-  <br>
-  <%= f.radio_button :is_home_during_day, false %> No
-
+      <h3>Are you or another adult home during the day?</h3>
+      <%= f.radio_button :is_home_during_day, true, id: "is_home_during_day_true" %> 
+      <%= f.label :is_home_during_day, "Yes" %>
+      <br>
+      <%= f.radio_button :is_home_during_day, false, id: "is_home_during_day_false" %>
+      <%= f.label :is_home_during_day, "No" %>
 </div>
 
 <h4>Tell us about your household</h4>
 
-<%= f.fields_for :homes do |home| %>
-  <%= home.check_box :has_fenced_yard, :value => true %>
-  <%= home.label :has_fenced_yard, "Fenced Yard" %>
+<%= f.fields_for :home, Home.new() do |home_attributes| %>
+  <%= home_attributes.check_box :has_fenced_yard, :value => true %>
+  <%= home_attributes.label :has_fenced_yard, "Fenced Yard" %>
 
-  <%= home.check_box :has_children, :value => true  %>
-  <%= home.label :has_children, "Kids" %>
+  <%= home_attributes.check_box :has_children, :value => true  %>
+  <%= home_attributes.label :has_children, "Kids" %>
 
-  <%= home.check_box :has_other_adults, :value => true  %>
-  <%= home.label :has_other_adults, "Other Adults" %>
+  <%= home_attributes.check_box :has_other_adults, :value => true  %>
+  <%= home_attributes.label :has_other_adults, "Other Adults" %>
 
-  <%= home.check_box :has_other_dog, :value => true  %>
-  <%= home.label :has_other_dog, "Dog(s)" %>
+  <%= home_attributes.check_box :has_other_dog, :value => true  %>
+  <%= home_attributes.label :has_other_dog, "Dog(s)" %>
 
-  <%= home.check_box :has_other_cat, :value => true  %>
-  <%= home.label :has_other_cat, "Cat(s)" %>
+  <%= home_attributes.check_box :has_other_cat, :value => true  %>
+  <%= home_attributes.label :has_other_cat, "Cat(s)" %>
 <% end %>
 
 <br />

--- a/app/views/signups/new.html.erb
+++ b/app/views/signups/new.html.erb
@@ -27,15 +27,6 @@
 
   <%= render "home_section", f: f %>
   <%= render "application_section", f: f %>
-  
-    <div class="home-during-day-field">
-      <h3>Are you or another adult home during the day?</h3>
-      <%= f.radio_button :is_home_during_day, true, id: "is_home_during_day_true" %> 
-      <%= f.label :is_home_during_day, "Yes" %>
-      <br>
-      <%= f.radio_button :is_home_during_day, false, id: "is_home_during_day_false" %>
-      <%= f.label :is_home_during_day, "No" %>
-    </div>
     <div class="transportation-field">
       <h3>Transportation</h3>
       <p><%= f.label :transportation, 'Can you drive?' %>

--- a/db/migrate/20210927225655_add_home_to_fosters.rb
+++ b/db/migrate/20210927225655_add_home_to_fosters.rb
@@ -1,0 +1,5 @@
+class AddHomeToFosters < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :homes, :foster, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_26_130241) do
+ActiveRecord::Schema.define(version: 2021_09_27_225655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,20 +51,23 @@ ActiveRecord::Schema.define(version: 2021_09_26_130241) do
     t.boolean "has_other_cat", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "foster_id", null: false
+    t.index ["foster_id"], name: "index_homes_on_foster_id"
   end
 
   create_table "passwordless_sessions", force: :cascade do |t|
     t.string "authenticatable_type"
     t.bigint "authenticatable_id"
-    t.datetime "timeout_at", null: false
-    t.datetime "expires_at", null: false
-    t.datetime "claimed_at"
+    t.datetime "timeout_at", precision: 6, null: false
+    t.datetime "expires_at", precision: 6, null: false
+    t.datetime "claimed_at", precision: 6
     t.text "user_agent", null: false
     t.string "remote_addr", null: false
     t.string "token", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["authenticatable_type", "authenticatable_id"], name: "authenticatable"
   end
 
+  add_foreign_key "homes", "fosters"
 end

--- a/test/controllers/fosters_controller_test.rb
+++ b/test/controllers/fosters_controller_test.rb
@@ -27,7 +27,7 @@ class FostersControllerTest < ActionDispatch::IntegrationTest
           street: 'Yo',
           apt: 'unit A',
           is_home_during_day: true,
-          transportation: "car"
+          transportation: "car",
         } 
       }
     end
@@ -53,7 +53,7 @@ class FostersControllerTest < ActionDispatch::IntegrationTest
         phone: '5714128473',
         street: 'Yo',
         apt: 'unit A',
-        is_home_during_day:true, 
+        is_home_during_day: true, 
         transportation: Foster.transportations()
       }
     }

--- a/test/controllers/homes_controller_test.rb
+++ b/test/controllers/homes_controller_test.rb
@@ -15,14 +15,6 @@ class HomesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should create home" do
-    assert_difference("Home.count") do
-      post homes_url, params: { home: { foster_id: 1 } }
-    end
-
-    assert_redirected_to home_url(Home.last)
-  end
-
   test "should show home" do
     get home_url(@home)
     assert_response :success

--- a/test/controllers/homes_controller_test.rb
+++ b/test/controllers/homes_controller_test.rb
@@ -17,7 +17,7 @@ class HomesControllerTest < ActionDispatch::IntegrationTest
 
   test "should create home" do
     assert_difference("Home.count") do
-      post homes_url, params: { home: {  } }
+      post homes_url, params: { home: { foster_id: 1 } }
     end
 
     assert_redirected_to home_url(Home.last)

--- a/test/fixtures/fosters.yml
+++ b/test/fixtures/fosters.yml
@@ -5,6 +5,7 @@
 # below each fixture, per the syntax in the comments below
 #
 one:
+  id: 1
   full_name: "Chuck Norris"
   email: "peter@gihub.com"
   street: "123 Sesame street"

--- a/test/fixtures/homes.yml
+++ b/test/fixtures/homes.yml
@@ -10,3 +10,4 @@ one:
   has_other_adults: true
   has_other_dog: false
   has_other_cat: false
+  foster_id: 1

--- a/test/models/home_test.rb
+++ b/test/models/home_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class HomeTest < ActiveSupport::TestCase
-  test 'valid home' do
+  test 'valid home has foster_id' do
     attrs = create_home_attributes({ has_fenced_yard: true })
     home = Home.new(attrs)
 
@@ -10,7 +10,7 @@ class HomeTest < ActiveSupport::TestCase
   end
 
   test 'defaults all attrs to false' do
-    home = Home.new
+    home = Home.new(foster_id: 1)
     assert home.valid?
   end
 
@@ -20,7 +20,8 @@ class HomeTest < ActiveSupport::TestCase
       has_fenced_yard: opts[:has_fenced_yard] || false,
       has_other_adults: opts[:has_other_adults] || false,
       has_other_dog: opts[:has_other_dog] || false,
-      has_other_cat: opts[:has_other_cat] || false
+      has_other_cat: opts[:has_other_cat] || false,
+      foster_id: 1
     }
   end
 end

--- a/test/system/homes_test.rb
+++ b/test/system/homes_test.rb
@@ -9,14 +9,4 @@ class HomesTest < ApplicationSystemTestCase
     visit homes_url
     assert_selector "h1", text: "Home"
   end
-
-  test "should create Home" do
-    visit homes_url
-    click_on "New Home"
-
-    click_on "Create Home"
-
-    assert_text "Home was successfully created"
-    click_on "Back"
-  end
 end


### PR DESCRIPTION
I did this as a first step to make sure I'm on the right track before moving the transportation, home type, and available during the day fields over to the Homes table as well.

A few other things:

1. I had to add the `rexml` gem to get my tests to start passing. I was wondering if I had environment issues, but with this gem, the tests are passing.
2. I got rid of the extra "available during the day" field from the UI.
3. I removed the post endpoint for homes, because I don't think we would create them in any other way at the moment, right? A home gets created when a foster signs up. I can't think of a reason to create a home by itself. We'd definitely want to update information about it, but creating new ones only happens upon signup.
4. I got a security vulnerability warning for the `nokogiri` gem. I think the `rexml` gem depends on that. Is there anything we can do to remediate that?
5. In general, I want to make sure I'm doing things the right way and am not adding anything here unnecessarily.

UI for reference:

<img width="1412" alt="image" src="https://user-images.githubusercontent.com/483359/135005815-dc3e0e12-f259-47c6-8af5-15f8107dcc7f.png">
