### PR TITLE
Cleanup database fields

### DIFF
--- a/db/migrate/20220115204940_remove_homes_fields_from_people.rb
+++ b/db/migrate/20220115204940_remove_homes_fields_from_people.rb
@@ -1,0 +1,11 @@
+class RemoveHomesFieldsFromPeople < ActiveRecord::Migration[7.0]
+def up
+    remove_column :people, :street
+    remove_column :people, :apt
+  end
+
+  def down
+    add_column :people, :street, :string, null: false
+    add_column :people, :apt, :string
+  end
+end

--- a/db/migrate/20220115205410_fix_types_in_person_animals_table.rb
+++ b/db/migrate/20220115205410_fix_types_in_person_animals_table.rb
@@ -1,0 +1,17 @@
+class FixTypesInPersonAnimalsTable < ActiveRecord::Migration[7.0]
+  def up
+    change_column :person_animals, :person_id, :bigint
+    change_column :person_animals, :animal_id, :bigint
+
+    add_foreign_key :person_animals, :people
+    add_foreign_key :person_animals, :animals
+  end
+
+  def down
+    remove_foreign_key :person_animals, :people
+    remove_foreign_key :person_animals, :animals
+
+    change_column :person_animals, :person_id, :integer
+    change_column :person_animals, :animal_id, :integer
+  end
+end

--- a/db/migrate/20220115211102_add_fk_constraints_on_people_roles.rb
+++ b/db/migrate/20220115211102_add_fk_constraints_on_people_roles.rb
@@ -1,0 +1,11 @@
+class AddFkConstraintsOnPeopleRoles < ActiveRecord::Migration[7.0]
+  def up
+    add_foreign_key :people_roles, :people
+    add_foreign_key :people_roles, :roles
+  end
+
+  def down
+    remove_foreign_key :people_roles, :people
+    remove_foreign_key :people_roles, :roles
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_15_150227) do
+ActiveRecord::Schema.define(version: 2022_01_15_204940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,14 +87,14 @@ ActiveRecord::Schema.define(version: 2021_10_15_150227) do
   create_table "passwordless_sessions", force: :cascade do |t|
     t.string "authenticatable_type"
     t.bigint "authenticatable_id"
-    t.datetime "timeout_at", null: false
-    t.datetime "expires_at", null: false
-    t.datetime "claimed_at"
+    t.datetime "timeout_at", precision: 6, null: false
+    t.datetime "expires_at", precision: 6, null: false
+    t.datetime "claimed_at", precision: 6
     t.text "user_agent", null: false
     t.string "remote_addr", null: false
     t.string "token", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
     t.index ["authenticatable_type", "authenticatable_id"], name: "authenticatable"
   end
 
@@ -104,8 +104,6 @@ ActiveRecord::Schema.define(version: 2021_10_15_150227) do
     t.string "email", default: "", null: false
     t.boolean "is_home_during_day", null: false
     t.integer "transportation", null: false
-    t.string "street"
-    t.string "apt"
     t.string "phone", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_15_204940) do
+ActiveRecord::Schema.define(version: 2022_01_15_205410) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,8 +124,8 @@ ActiveRecord::Schema.define(version: 2022_01_15_204940) do
   end
 
   create_table "person_animals", force: :cascade do |t|
-    t.integer "animal_id"
-    t.integer "person_id"
+    t.bigint "animal_id"
+    t.bigint "person_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -162,6 +162,8 @@ ActiveRecord::Schema.define(version: 2022_01_15_204940) do
   add_foreign_key "animal_gender_preferences", "people"
   add_foreign_key "animal_kind_preferences", "people"
   add_foreign_key "animal_size_preferences", "people"
+  add_foreign_key "person_animals", "animals"
+  add_foreign_key "person_animals", "people"
   add_foreign_key "person_homes", "homes"
   add_foreign_key "person_homes", "people"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_15_205410) do
+ActiveRecord::Schema.define(version: 2022_01_15_211102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,6 +162,8 @@ ActiveRecord::Schema.define(version: 2022_01_15_205410) do
   add_foreign_key "animal_gender_preferences", "people"
   add_foreign_key "animal_kind_preferences", "people"
   add_foreign_key "animal_size_preferences", "people"
+  add_foreign_key "people_roles", "people"
+  add_foreign_key "people_roles", "roles"
   add_foreign_key "person_animals", "animals"
   add_foreign_key "person_animals", "people"
   add_foreign_key "person_homes", "homes"


### PR DESCRIPTION
During the big PR that added the signup form, we left a few corners of the database a bit out of sorts. This PR fixes those up.

1. Removes now-unused columns for `street` and `apt` from the `people` table since they moved to the `homes` table. _The signup for was already putting the data in the `homes` table._
2. Updates the relation fields in `person_animals` to be `bigint` values vs. `int` so they match the types of their related tables. Also adds foreign key constraints on them like the other tables in the database.
3. Adds relevant foreign key constraints to the `people_roles` table.