### PR TITLE
Update README to utilize bin/dev to start server

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ Note: a `.tool-versions` file exists which contains the current supported ruby v
 
 ## Running the app
 
+
 ```
-rails s
+bin/dev
 ```
 
 ## Design


### PR DESCRIPTION
It is recommended to use `bin/dev` instead of `rails s` because bin/dev kicks off the process for compiling js & CSS. Running `rails s` by itself wouldn't include catching updates or changes to styling or javascript.