### PR TITLE
Utilize bin/setup script to handle application setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,7 @@ All commands in code font are to be copied and pasted onto command line.
 1. `brew install yarn`
 1. `cd path/to/shelter-assist`
 1. `brew install postgresql` (idk, bundle didn't work until I installed this first)
-1. `bundle install`
-1. `yarn install`
-1. `brew services restart postgresql`
-1. `bin/rails db:create`
-1. `bin/rails db:migrate RAILS_ENV=development`
-1. `gem install foreman`
-1. `bin/dev`
+1. `bin/setup`
 
 ## Optional ASDF-VM Support
 

--- a/bin/setup
+++ b/bin/setup
@@ -4,30 +4,66 @@ require "fileutils"
 # path to your application root.
 APP_ROOT = File.expand_path("..", __dir__)
 
+#
+## Prints the log message with a yellow color to distinguish logs
+# See more information here - https://stackoverflow.com/questions/1489183/how-can-i-use-ruby-to-colorize-the-text-output-to-a-terminal
+# #
+def log(message, color: :yellow)
+  color_code = if color == :yellow
+                 "33"
+               elsif color == :red
+                 "31"
+               else
+                 "37"
+               end
+
+  printf "\033[1;#{color_code}m";
+
+  puts "\n[ bin/setup ] #{message}"
+
+  printf "\033[0m"
+end
+
+
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
 FileUtils.chdir APP_ROOT do
+  log "---------------------"
+  log "🐕 Setup started... 🐕"
+  log "---------------------"
+
   # This script is a way to set up or update your development environment automatically.
   # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  puts "== Installing dependencies =="
+  log "== Installing dependencies =="
+  system! "gem install foreman"
   system! "gem install bundler --conservative"
-  system("bundle check") || system!("bundle install")
+  system!("bundle update --bundler --verbose")
+  system!("bundle check") || system!("bundle install")
 
+  # Install JavaScript dependencies if using Yarn
+  log '== Installing javascript dependencies via yarn == '
+  system('bin/yarn')
+
+  #
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
   # end
 
-  puts "\n== Preparing database =="
+  log "== Preparing database =="
   system! "bin/rails db:prepare"
 
-  puts "\n== Removing old logs and tempfiles =="
+  log "== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 
-  puts "\n== Restarting application server =="
+  log "== Restarting application server =="
   system! "bin/rails restart"
+
+  log "---------------------"
+  log "🐕 Done! Run bin/dev to run the application locally at http://localhost:3000 🐕"
+  log "---------------------"
 end


### PR DESCRIPTION
This PR updates the README to suggest using `bin/setup` to source control the configuration steps. I've found this to be useful so that we keep the steps simple and consistent.

Here is an
<img width="907" alt="Captura de Pantalla 2022-08-22 a la(s) 8 32 33 p m" src="https://user-images.githubusercontent.com/11335191/186049020-f807db66-2cb3-4355-9c28-05ca99df1b9f.png">
 output log of what it looks like. And yes I added a dog emoji:
<img width="693" alt="Captura de Pantalla 2022-08-22 a la(s) 8 32 27 p m" src="https://user-images.githubusercontent.com/11335191/186049006-9e7f9edf-8ee6-4426-a983-220357482588.png">

You should now be able to get the application prepared relatively quickly assuming you have ruby, Postgres, and yarn installed.
